### PR TITLE
Update API for EncryptedValue.ToSerializable()

### DIFF
--- a/encryptedconfigvalue/aesgcm.go
+++ b/encryptedconfigvalue/aesgcm.go
@@ -133,6 +133,6 @@ func (ev *aesGCMEncryptedValue) Decrypt(key KeyWithType) (string, error) {
 	return string(decrypted), err
 }
 
-func (ev *aesGCMEncryptedValue) ToSerializable() (string, error) {
+func (ev *aesGCMEncryptedValue) ToSerializable() string {
 	return encryptedValToSerializable(ev)
 }

--- a/encryptedconfigvalue/encryptedvalue_utils.go
+++ b/encryptedconfigvalue/encryptedvalue_utils.go
@@ -69,11 +69,7 @@ func NormalizeEncryptedValueStringVars(input []byte, key KeyWithType, normalized
 		// if an entry for the plaintext of the current encrypted value exists in the normalized map, replace
 		// the encrypted value with the normalized one.
 		if sub, present := normalized[plaintext]; present {
-			newVal, err := sub.ToSerializable()
-			if err != nil {
-				return raw, true
-			}
-			return []byte(newVal), true
+			return []byte(sub.ToSerializable()), true
 		}
 		// this is the first time that this plaintext has been encountered for an encrypted value. Store the
 		// current encrypted value as the value for the plaintext in the map so that all subsequent occurrences

--- a/encryptedconfigvalue/keypair_test.go
+++ b/encryptedconfigvalue/keypair_test.go
@@ -28,7 +28,7 @@ func TestKeyWithTypeAndEncryptedValSerDe(t *testing.T) {
 		// create encrypted value and serialize
 		ev, err := encrypter.Encrypt(wantPlaintext, kp.EncryptionKey)
 		require.NoError(t, err, "Case %d: %s", i, currAlg)
-		evStr, err := ev.ToSerializable()
+		evStr := ev.ToSerializable()
 		require.NoError(t, err, "Case %d: %s", i, currAlg)
 
 		// serialize decryption key

--- a/encryptedconfigvalue/legacy_encryptedvalue.go
+++ b/encryptedconfigvalue/legacy_encryptedvalue.go
@@ -42,6 +42,6 @@ func (ev *legacyEncryptedValue) Decrypt(key KeyWithType) (string, error) {
 // ToSerializable returns the serializable representation for this legacy encrypted value, which is of the form:
 // "enc:<base64-encoded-ciphertext-bytes>". For AES values, the ciphertext bytes are "nonce+ciphertext+tag", while for
 // RSA values the ciphertext is the raw ciphertext.
-func (ev *legacyEncryptedValue) ToSerializable() (string, error) {
-	return fmt.Sprintf(encPrefix + base64.StdEncoding.EncodeToString(ev.encryptedBytes)), nil
+func (ev *legacyEncryptedValue) ToSerializable() string {
+	return fmt.Sprintf(encPrefix + base64.StdEncoding.EncodeToString(ev.encryptedBytes))
 }

--- a/encryptedconfigvalue/rsaoaep.go
+++ b/encryptedconfigvalue/rsaoaep.go
@@ -127,6 +127,6 @@ func (ev *rsaOAEPEncryptedValue) Decrypt(key KeyWithType) (string, error) {
 	return string(decrypted), err
 }
 
-func (ev *rsaOAEPEncryptedValue) ToSerializable() (string, error) {
+func (ev *rsaOAEPEncryptedValue) ToSerializable() string {
 	return encryptedValToSerializable(ev)
 }


### PR DESCRIPTION
Remove error return type and make the underlying implementation
panic. Appropriate because values are assumed to be well-formed,
and the inability to serialize is considered a programmer error.